### PR TITLE
Update for PureScript 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,8 +15,8 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-strongcheck": "^2.0.1",
-    "purescript-argonaut": "^2.0.0",
-    "purescript-newtype": "^1.3.0"
+    "purescript-strongcheck": "^3.0.0",
+    "purescript-argonaut": "^3.0.0",
+    "purescript-newtype": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^10.0.0",
-    "purescript": "^0.10.2",
-    "purescript-psa": "^0.4.0",
+    "pulp": "^11.0.0",
+    "purescript": "^0.11.0",
+    "purescript-psa": "^0.5.0",
     "rimraf": "^2.5.4"
   }
 }


### PR DESCRIPTION
This shouldn't pass CI checks yet because `purescript-argonaut` 3.0.0 doesn't exist yet, but it should soon!